### PR TITLE
in python2.7, format field numbers are optional. in 2.6 they are not.

### DIFF
--- a/sql_to_graphite/__init__.py
+++ b/sql_to_graphite/__init__.py
@@ -26,7 +26,7 @@ def run(graphite_host, graphite_port, graphite_prefix, queries, executor):
     for result in data:
         for line in result:
             metric, value = line[:2]
-            metric = '{}.{} {} {}\n'.format(graphite_prefix, metric, value, now)
+            metric = '{0}.{1} {2} {3}\n'.format(graphite_prefix, metric, value, now)
             print metric,
             sock.sendall(metric)
     sock.close()


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "$HOME/sql2graphite/bin/sql-to-graphite", line 9, in <module>
    load_entry_point('sql-to-graphite==0.0.6', 'console_scripts', 'sql-to-graphite')()
  File "$HOME/sql2graphite/lib/python2.6/site-packages/sql_to_graphite/__init__.py", line 56, in main
    get_executor(dsn),
  File "$HOME/sql2graphite/lib/python2.6/site-packages/sql_to_graphite/__init__.py", line 30, in run
    metric = '{}.{} {} {}\n'.format(graphite_prefix, metric, value, now)
ValueError: zero length field name in format
```

http://stackoverflow.com/questions/5446964/valueerror-zero-length-field-name-in-format-error-in-python-3-0-3-1-3-2/8498327#8498327

RHEL/CentOS still ships 2.6